### PR TITLE
Detect symlinks on Windows.

### DIFF
--- a/fileutils/file_utils_notwin.go
+++ b/fileutils/file_utils_notwin.go
@@ -1,0 +1,13 @@
+//
+
+// +build !windows
+
+package fileutils
+
+import (
+	"os"
+)
+
+func IsRegular(f os.FileInfo) bool {
+	return f.Mode().IsRegular()
+}

--- a/fileutils/file_utils_windows.go
+++ b/fileutils/file_utils_windows.go
@@ -1,0 +1,20 @@
+package fileutils
+
+import (
+	"os"
+	"syscall"
+)
+
+const (
+	FILE_ATTRIBUTE_REPARSE_POINT = 0x0400
+)
+
+func IsRegular(f os.FileInfo) bool {
+	if fileattrs, ok := f.Sys().(*syscall.Win32FileAttributeData); ok {
+		println("FILEATTRS", f.Name(), fileattrs.FileAttributes)
+		if fileattrs.FileAttributes&FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+			return false
+		}
+	}
+	return f.Mode().IsRegular()
+}


### PR DESCRIPTION
This supports symlinks only, no hard link detection

Any test case would require administrative privileges to run in order to create the symlink.
